### PR TITLE
Install certificates when restart() is called

### DIFF
--- a/certbot_s3front/installer.py
+++ b/certbot_s3front/installer.py
@@ -3,9 +3,9 @@
 from __future__ import print_function
 
 import os
+import os.path
 import sys
 import logging
-import time
 
 import zope.interface
 
@@ -61,17 +61,28 @@ class Installer(common.Plugin):
         key = open(key_path).read()
         chain = open(chain_path).read()
 
-        suffix = "-%i" % int(time.time())
+        suffix = "-%i" % int(os.path.getmtime(cert_path))
 
-        # Upload cert to IAM
-        response = client.upload_server_certificate(
-            Path="/cloudfront/letsencrypt/",
-            ServerCertificateName=name + suffix,
-            CertificateBody=body,
-            PrivateKey=key,
-            CertificateChain=chain
+        # Check if certificate already exists
+        certificates = client.list_server_certificates(
+            PathPrefix="/cloudfront/letsencrypt/"
         )
-        cert_id = response['ServerCertificateMetadata']['ServerCertificateId']
+        cert_id = None
+        for cert in certificates['ServerCertificateMetadataList']:
+            if cert['ServerCertificateName'] == (name + suffix):
+                cert_id = cert['ServerCertificateId']
+
+        # If certificate doesn't already exists, upload cert to IAM
+        if not cert_id:
+            response = client.upload_server_certificate(
+                Path="/cloudfront/letsencrypt/",
+                ServerCertificateName=name + suffix,
+                CertificateBody=body,
+                PrivateKey=key,
+                CertificateChain=chain
+            )
+            cert_id = response['ServerCertificateMetadata']['ServerCertificateId']
+
         # Update CloudFront config to use the new one
         cf_cfg = cf_client.get_distribution_config(Id=self.conf('cf-distribution-id'))
         cf_cfg['DistributionConfig']['ViewerCertificate']['IAMCertificateId'] = cert_id
@@ -134,5 +145,19 @@ class Installer(common.Plugin):
     def config_test(self):  # pylint: disable=missing-docstring,no-self-use
         pass  # pragma: no cover
 
-    def restart(self):  # pylint: disable=missing-docstring,no-self-use
-        pass  # pragma: no cover
+    def restart(self):
+        client = boto3.client('iam')
+        certificates = client.list_server_certificates(
+            PathPrefix="/cloudfront/letsencrypt/"
+        )
+        for cert in certificates['ServerCertificateMetadataList']:
+            domain = cert['ServerCertificateName']
+            cert_path = os.path.join(self.config.live_dir, domain, 'cert.pem')
+            chain_path = os.path.join(self.config.live_dir, domain, 'chain.pem')
+            fullchain_path = os.path.join(self.config.live_dir, domain, 'fullchain.pem')
+            key_path = os.path.join(self.config.live_dir, domain, 'privkey.pem')
+            try:
+                open(cert_path, 'r')
+            except IOError:
+                continue
+            self.deploy_cert(domain, cert_path, key_path, chain_path, fullchain_path)


### PR DESCRIPTION
See https://github.com/certbot/certbot/issues/4046

This is needed since certbot does not call the deploy_cert() method
when doing a renewal.